### PR TITLE
Simplify barys command

### DIFF
--- a/pages/docs/custombuild.md
+++ b/pages/docs/custombuild.md
@@ -17,7 +17,7 @@ from with in the repo.
 
 Now to actually build a development version of resinOS for the Raspberry Pi 3, we can run the following:
 ``` bash
-./resin-yocto-scripts/build/barys -r --shared-downloads $(pwd)/shared-downloads/ --shared-sstate $(pwd)/shared-sstate/ -m raspberrypi3
+./resin-yocto-scripts/build/barys -m raspberrypi3
 ```
 
 **NOTE:** To create a managed build (one that communicates with and can be managed through resin.io's services),


### PR DESCRIPTION
./resin-yocto-scripts/build/barys -r --shared-downloads $(pwd)/shared-downloads/ --shared-sstate $(pwd)/shared-sstate/ -m raspberrypi3

should be simplified to

./resin-yocto-scripts/build/barys -m raspberrypi3

The extra parameters are useful for developers that keep building resinos but irrelevant for someone getting started